### PR TITLE
Updated button styling

### DIFF
--- a/src/components/Buttons/Button/Button.module.scss
+++ b/src/components/Buttons/Button/Button.module.scss
@@ -3,8 +3,8 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  width: fit-content;
-  min-width: fit-content;
+  width: max-content;
+  min-width: max-content;
   user-select: none;
   line-height: 24px;
   &.small {


### PR DESCRIPTION
Fix for this:
![image-20240318-072336](https://github.com/arbolus-technologies/arbolus-components/assets/20415001/60f8b3bc-11b7-4fe3-871f-9c6c9ec0600c)

Explanation: (https://stackoverflow.com/questions/30704073/what-is-the-difference-between-css-fit-content-and-max-content)
**fit-content uses max-content**, unless available < max-content, then it uses **available**. Unless available < min-content, then it uses **min-content**.